### PR TITLE
Fix incorrect traps in vunit

### DIFF
--- a/bin/vunit
+++ b/bin/vunit
@@ -124,8 +124,8 @@ if [ $OUTPUT = FILE ]; then
   outfile=`mktemp -t vunit_results.XXXXXXXXXX`
   check_path "$outfile"
   trap - EXIT HUP INT QUIT TERM
-  trap 'rm -f "$outfile"; cd "$tcdir" exit 0' EXIT
-  trap 'rm -f "$outfile"; cd "$tcdir" exit 1' HUP INT QUIT TERM
+  trap 'rm -f "$outfile"; cd "$cwd"; exit 0' EXIT
+  trap 'rm -f "$outfile"; cd "$cwd"; exit 1' HUP INT QUIT TERM
 
   $VIM -c "UnitTest $tcfile >$outfile" -c "qall!"
 


### PR DESCRIPTION
This PR fixes a long-standing issue in `vunit`. After a test run, `vunit` would error out with:

    /path/to/bin/vunit: line 1: cd: too many arguments

This was the result of a missing semicolon between `cd` and `exit`. I also believe `$tcdir` may not have been correct as it would also result in an error since the script was already in that directory. I changed it to to `$cwd` since that seemed to be the original intent.