### PR TITLE
This is a bugfix for various internal errors (e.g. 's:Assertions not found')

### DIFF
--- a/autoload/unittest.vim
+++ b/autoload/unittest.vim
@@ -90,7 +90,7 @@ function! unittest#print_error(msg)
 endfunction
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+    return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/assertions.vim
+++ b/autoload/unittest/assertions.vim
@@ -36,7 +36,7 @@ function! unittest#assertions#__context__()
 endfunction
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/oop.vim
+++ b/autoload/unittest/oop.vim
@@ -46,7 +46,7 @@ function! unittest#oop#__constant__(name)
 endfunction
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/oop/class.vim
+++ b/autoload/unittest/oop/class.vim
@@ -36,7 +36,7 @@ let s:TYPE_NUM  = type(0)
 let s:TYPE_FUNC = type(function('tr'))
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/oop/module.vim
+++ b/autoload/unittest/oop/module.vim
@@ -35,7 +35,7 @@ set cpo&vim
 let s:TYPE_NUM  = type(0)
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/testcase.vim
+++ b/autoload/unittest/testcase.vim
@@ -32,7 +32,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID


### PR DESCRIPTION
`UnitTest` makes use of funcrefs defined as local script functions.
To allow the creation of a funcref, one should get the unique ID of the script that contains the function.
For example, the object `s:Assertions` that is defined in some script in the plugin's `autoload` path can be referenced as e.g. `<SNR>96_Assertions`
The functions `get_SID()` in the plugin's scripts are responsible for finding the sequence `<SNR>XXX_` from `<sfile>` to reference local functions in this script.

Sadly, the expansion of the `<sfile>`  have multiple occurences of the original match pattern and returned the SID of the base script, thus leading to invalid funcrefs.

Here's an example for the `get_SID()` function in `autoload/unittest/oop/module.vim`
The `<sfile>` expands to  `function unittest#run[8]..<SNR>90_TestRunner_load_testcases[5]..script test_yank_vhd.vim[74]..vim-unittest/autoload/unittest/testcase.
vim[70]..vim-unittest/autoload/unittest/assertions.vim[61]..vim-unittest/autoload/unittest/oop/module.vim[41]..function <SNR>96_get_SID`

The actual `<SID>` for the script `autoload/unittest/oop/module.vim` should be `<SNR>96_` but the original match pattern was capturing the first occurence of it (`<SNR>90_`), thus matching script `autoload/unittest.vim` instead of `autoload/unittest/oop/module.vim`
