### PR TITLE
BUGFIX: 's:Asserts' not found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,4 @@ jobs:
         run: sudo apt-get install vim
       - run: ls
       - run: tree
+      - run: pwd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,4 @@ jobs:
       - name: "Tree"
         run: tree -d ~/
       - name: "UnitTests"
-        run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim
+        run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,10 @@
+on:
+  push:
+    branches:
+    - master
+    - devel
+jobs:
+  test:
+    runs-on: [ubuntu-latest]
+    steps:
+    - run: echo Hello world!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,7 @@ jobs:
         run: ln -s ~/work/vim-unittest/vim-unittest/runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
       - name: "Tree"
         run: tree -d ~/
+      - name: "Current dir"
+        run: pwd
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit -c none runtime/vim-unittest/test/test_almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
       - name: "Link to unittest in vim/bundle"
         run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
       - name: "Tree"
-        run: tree ~/
+        run: tree -d ~/
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
       - name: "Install Pathogen"
         run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Link to unittest in vim/bundle"
-        run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest
+        run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && cat ~/.vimrc
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,5 +16,7 @@ jobs:
         run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Link to unittest in vim/bundle"
         run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
+      - name: "Tree"
+        run: tree ~/
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
       - name: "Install Pathogen"
         run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Link to unittest in vim/bundle"
-        run: ln -s ~/.vim/bundle/vim-unittest runtime/vim-unittest
+        run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Automated tests for Continuous integration
 on: [push]
 jobs:
-  setup-environment:
+  run-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - name: "Create runtime path"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Create runtime path"
-        run:  "mkdir runtime"
+        run:  mkdir runtime
       - name: "Checkout Vim-Vlsim"
         uses: actions/checkout@v4.1.1
         with:
-          path: runtime
+          path: runtime/vim-unittest
       - name: "Install vim"
         run: sudo apt-get install vim
       - run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,4 +7,12 @@ jobs:
   test:
     runs-on: [ubuntu-latest]
     steps:
-    - run: echo Hello world!
+      - name: "Checkout Vim-Vlsim"
+          uses: actions/checkout@v4
+      - name: "Checkout Unittest"
+          uses: actions/checkout@v4
+          with: https://github.com/laurentalacoque/vim-unittest
+      - name: "Install vim"
+        run: apt-get install vim
+
+      - run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,11 @@
-on:
-  push:
-    branches:
-    - master
-    - devel
+name: Automated tests for Continuous integration
+on: [push]
 jobs:
-  test:
-    runs-on: [ubuntu-latest]
+  setup-environment:
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout Vim-Vlsim"
-          uses: actions/checkout@v4
-      - name: "Checkout Unittest"
-          uses: actions/checkout@v4
-          with: https://github.com/laurentalacoque/vim-unittest
+        uses: actions/checkout@v4
       - name: "Install vim"
         run: apt-get install vim
-
       - run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,4 @@ jobs:
       - name: "Tree"
         run: tree -d ~/
       - name: "UnitTests"
-        run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test/test-almost.vim
+        run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test/test_almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
       - name: "Install vim"
         run: sudo apt-get install vim
       - name: "Install Pathogen"
-        run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
+        run: mkdir -p ~/.vim/autoload && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Workspace"
         run: echo $GITHUB_WORKSPACE
       - name: "Link to unittest in vim/bundle"
-        run: ln -s ~/work/vim-unittest/vim-unittest/runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
+        run: ln -s $GITHUB_WORKSPACE/runtime/ ~/.vim/bundle && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
       - name: "Tree"
         run: tree -d ~/
       - name: "Current dir"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install Pathogen"
         run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Link to unittest in vim/bundle"
-        run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
+        run: ln -s ~/work/vim-unittest/vim-unittest/runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
       - name: "Tree"
         run: tree -d ~/
       - name: "UnitTests"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,5 @@ jobs:
           path: runtime/vim-unittest
       - name: "Install vim"
         run: sudo apt-get install vim
-      - run: ls
-      - run: tree
-      - run: pwd
+      - name: "UnitTests"
+        run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
         run: sudo apt-get install vim
       - name: "Install Pathogen"
         run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
+      - name: "Workspace"
+        run: echo $GITHUB_WORKSPACE
       - name: "Link to unittest in vim/bundle"
         run: ln -s ~/work/vim-unittest/vim-unittest/runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
       - name: "Tree"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "Install vim"
         run: sudo apt-get install vim
       - name: "Install Pathogen"
-        run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vim
+        run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Link to unittest in vim/bundle"
         run: ln -s ~/.vim/bundle/vim-unittest runtime/vim-unittest
       - name: "UnitTests"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,4 @@ jobs:
       - name: "Tree"
         run: tree -d ~/
       - name: "UnitTests"
-        run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test/test_almost.vim
+        run: runtime/vim-unittest/bin/vunit -c none runtime/vim-unittest/test/test_almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,11 @@ jobs:
   setup-environment:
     runs-on: ubuntu-latest
     steps:
+      - name: "Create runtime path"
+        run:  "mkdir runtime"
       - name: "Checkout Vim-Vlsim"
         uses: actions/checkout@v4
+        path: "runtime"
       - name: "Install vim"
         run: sudo apt-get install vim
       - run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
         run:  "mkdir runtime"
       - name: "Checkout Vim-Vlsim"
         uses: actions/checkout@v4
-        path: "runtime"
+        path: runtime
       - name: "Install vim"
         run: sudo apt-get install vim
       - run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,9 @@ jobs:
           path: runtime/vim-unittest
       - name: "Install vim"
         run: sudo apt-get install vim
+      - name: "Install Pathogen"
+        run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vim
+      - name: "Link to unittest in vim/bundle"
+        run: ln -s ~/.vim/bundle/vim-unittest runtime/vim-unittest
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,5 +7,6 @@ jobs:
       - name: "Checkout Vim-Vlsim"
         uses: actions/checkout@v4
       - name: "Install vim"
-        run: apt-get install vim
+        run: sudo apt-get install vim
       - run: ls
+      - run: tree

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,9 @@ jobs:
       - name: "Create runtime path"
         run:  "mkdir runtime"
       - name: "Checkout Vim-Vlsim"
-        uses: actions/checkout@v4
-        path: runtime
+        uses: actions/checkout@v4.1.1
+        with:
+          path: runtime
       - name: "Install vim"
         run: sudo apt-get install vim
       - run: ls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,6 @@ jobs:
       - name: "Install Pathogen"
         run: mkdir -p ~/.vim/autoload ~/.vim/bundle && curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim && echo "execute pathogen#infect()" > ~/.vimrc
       - name: "Link to unittest in vim/bundle"
-        run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && cat ~/.vimrc
+        run: ln -s runtime/vim-unittest ~/.vim/bundle/vim-unittest && ls -l ~/.vim/bundle && ls -l ~/.vim/bundle/vim-unittest && cat ~/.vimrc
       - name: "UnitTests"
         run: runtime/vim-unittest/bin/vunit runtime/vim-unittest/test-almost.vim

--- a/autoload/unittest.vim
+++ b/autoload/unittest.vim
@@ -90,7 +90,7 @@ function! unittest#print_error(msg)
 endfunction
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+    return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest.vim
+++ b/autoload/unittest.vim
@@ -210,12 +210,14 @@ call s:TestRunner.method('count_assertion')
 
 function! s:TestRunner_report_success() dict
   call self.results.add_success(self.current.testcase, self.current.test)
+  return 1
 endfunction
 call s:TestRunner.method('report_success')
 
 function! s:TestRunner_report_failure(reason, hint) dict
   call self.results.add_failure(self.current.testcase, self.current.test,
         \ a:reason, a:hint)
+  return 0
 endfunction
 call s:TestRunner.method('report_failure')
 

--- a/autoload/unittest/assertions.vim
+++ b/autoload/unittest/assertions.vim
@@ -36,7 +36,7 @@ function! unittest#assertions#__context__()
 endfunction
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/assertions.vim
+++ b/autoload/unittest/assertions.vim
@@ -505,6 +505,21 @@ endfunction
 call s:Assertions.function('assert_not_throw')
 call s:Assertions.alias('assert_nothing_thrown', 'assert_not_throw')
 
+function! s:Assertions_fail(...) dict
+  call self.count_assertion()
+  let hint = (a:0 ? a:1 : "")
+  return self.report_failure(
+          \ "",
+          \ hint)
+endfunction
+call s:Assertions.function('fail')
+
+function! s:Assertions_pass() dict
+  call self.count_assertion()
+  return self.report_success()
+endfunction
+call s:Assertions.function('pass')
+
 function! s:Assertions___string__(value)
   return unittest#oop#string(a:value)
 endfunction

--- a/autoload/unittest/assertions.vim
+++ b/autoload/unittest/assertions.vim
@@ -64,11 +64,11 @@ function! s:Assertions_assert(expr, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if !a:expr
-    call self.report_failure(
+    return self.report_failure(
           \ printf("True expected, but was\n%s", self.__string__(a:expr)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert')
@@ -77,11 +77,11 @@ function! s:Assertions_assert_not(expr, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expr
-    call self.report_failure(
+    return self.report_failure(
           \ printf("False expected, but was\n%s", self.__string__(a:expr)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not')
@@ -91,21 +91,21 @@ function! s:Assertions_assert_equal(expected, actual, ...) dict
   let hint = (a:0 ? a:1 : "")
   if type(a:expected) == s:TYPE_STR && type(a:actual) == s:TYPE_STR
     if a:expected !=# a:actual
-      call self.report_failure(
+      return self.report_failure(
             \ printf("%s expected, but was\n%s",
             \   self.__string__(a:expected), self.__string__(a:actual)),
             \ hint)
     else
-      call self.report_success()
+      return self.report_success()
     endif
   else
     if a:expected != a:actual
-      call self.report_failure(
+      return self.report_failure(
             \ printf("%s expected, but was\n%s",
             \   self.__string__(a:expected), self.__string__(a:actual)),
             \ hint)
     else
-      call self.report_success()
+      return self.report_success()
     endif
   endif
 endfunction
@@ -116,21 +116,21 @@ function! s:Assertions_assert_not_equal(expected, actual, ...) dict
   let hint = (a:0 ? a:1 : "")
   if type(a:expected) == s:TYPE_STR && type(a:actual) == s:TYPE_STR
     if a:expected ==# a:actual
-      call self.report_failure(
+      return self.report_failure(
             \ printf("%s not expected, but was\n%s",
             \   self.__string__(a:expected), self.__string__(a:actual)),
             \ hint)
     else
-      call self.report_success()
+      return self.report_success()
     endif
   else
     if a:expected == a:actual
-      call self.report_failure(
+      return self.report_failure(
             \ printf("%s not expected, but was\n%s",
             \   self.__string__(a:expected), self.__string__(a:actual)),
             \ hint)
     else
-      call self.report_success()
+      return self.report_success()
     endif
   endif
 endfunction
@@ -140,12 +140,12 @@ function! s:Assertions_assert_equal_c(expected, actual, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expected !=? a:actual
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s expected, but was\n%s",
           \   self.__string__(a:expected), self.__string__(a:actual)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_equal_c')
@@ -155,12 +155,12 @@ function! s:Assertions_assert_not_equal_c(expected, actual, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expected ==? a:actual
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s not expected, but was\n%s",
           \   self.__string__(a:expected), self.__string__(a:actual)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_equal_c')
@@ -170,12 +170,12 @@ function! s:Assertions_assert_equal_C(expected, actual, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expected !=# a:actual
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s expected, but was\n%s",
           \   self.__string__(a:expected), self.__string__(a:actual)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_equal_C')
@@ -185,12 +185,12 @@ function! s:Assertions_assert_not_equal_C(expected, actual, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expected ==# a:actual
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s not expected, but was\n%s",
           \   self.__string__(a:expected), self.__string__(a:actual)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_equal_C')
@@ -200,11 +200,11 @@ function! s:Assertions_assert_exists(expr, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expr =~ '^:' ? exists(a:expr) != 2 : !exists(a:expr)
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' is not defined.", a:expr),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_exists')
@@ -214,11 +214,11 @@ function! s:Assertions_assert_not_exists(expr, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expr =~ '^:' ? exists(a:expr) == 2 : exists(a:expr)
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' is defined.", a:expr),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_exists')
@@ -228,11 +228,11 @@ function! s:Assertions_assert_has_key(key, dict, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if !has_key(a:dict, a:key)
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s doesn't has key '%s'", self.__string__(a:dict), a:key),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_has_key')
@@ -241,11 +241,11 @@ function! s:Assertions_assert_not_has_key(key, dict, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if has_key(a:dict, a:key)
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s has key '%s'", self.__string__(a:dict), a:key),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_has_key')
@@ -254,12 +254,12 @@ function! s:Assertions_assert_is(expected, actual, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expected isnot a:actual
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s itself expected, but was\n%s",
           \   self.__string__(a:expected), self.__string__(a:actual)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is')
@@ -268,12 +268,12 @@ function! s:Assertions_assert_isnot(expected, actual, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:expected is a:actual
-    call self.report_failure(
+    return self.report_failure(
           \ printf("%s itself not expected, but was\n%s itself.",
           \   self.__string__(a:expected), self.__string__(a:actual)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_isnot')
@@ -283,11 +283,11 @@ function! s:Assertions_assert_is_Number(value, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if type(a:value) != s:TYPE_NUM
-    call self.report_failure(
+    return self.report_failure(
           \ printf("Number expected, but was\n%s", self.__typestr__(a:value)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is_Number')
@@ -296,11 +296,11 @@ function! s:Assertions_assert_is_String(value, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if type(a:value) != s:TYPE_STR
-    call self.report_failure(
+    return self.report_failure(
           \ printf("String expected, but was\n%s", self.__typestr__(a:value)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is_String')
@@ -309,11 +309,11 @@ function! s:Assertions_assert_is_Funcref(value, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if type(a:value) != s:TYPE_FUNC
-    call self.report_failure(
+    return self.report_failure(
           \ printf("Funcref expected, but was\n%s", self.__typestr__(a:value)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is_Funcref')
@@ -322,11 +322,11 @@ function! s:Assertions_assert_is_List(value, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if type(a:value) != s:TYPE_LIST
-    call self.report_failure(
+    return self.report_failure(
           \ printf("List expected, but was\n%s", self.__typestr__(a:value)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is_List')
@@ -335,11 +335,11 @@ function! s:Assertions_assert_is_Dictionary(value, ...) dict
   call self.count_assertion()
   if type(a:value) != s:TYPE_DICT
     let hint = (a:0 ? a:1 : "")
-    call self.report_failure(
+    return self.report_failure(
           \ printf("Dictionary expected, but was\n%s", self.__typestr__(a:value)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is_Dictionary')
@@ -349,11 +349,11 @@ function! s:Assertions_assert_is_Float(value, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if type(a:value) != s:TYPE_FLT
-    call self.report_failure(
+    return self.report_failure(
           \ printf("Float expected, but was\n%s", self.__typestr__(a:value)),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_is_Float')
@@ -380,11 +380,11 @@ function! s:Assertions_assert_match(pattern, str, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:str !~ a:pattern
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' didn't match pattern /%s/", a:str, a:pattern),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_match')
@@ -393,11 +393,11 @@ function! s:Assertions_assert_not_match(pattern, str, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:str =~ a:pattern
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' matched pattern /%s/", a:str, a:pattern),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_match')
@@ -406,11 +406,11 @@ function! s:Assertions_assert_match_c(pattern, str, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:str !~? a:pattern
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' didn't match pattern /%s/", a:str, a:pattern),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_match_c')
@@ -420,11 +420,11 @@ function! s:Assertions_assert_not_match_c(pattern, str, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:str =~? a:pattern
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' matched pattern /%s/", a:str, a:pattern),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_match_c')
@@ -434,11 +434,11 @@ function! s:Assertions_assert_match_C(pattern, str, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:str !~# a:pattern
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' didn't match pattern /%s/", a:str, a:pattern),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_match_C')
@@ -448,11 +448,11 @@ function! s:Assertions_assert_not_match_C(pattern, str, ...) dict
   call self.count_assertion()
   let hint = (a:0 ? a:1 : "")
   if a:str =~# a:pattern
-    call self.report_failure(
+    return self.report_failure(
           \ printf("'%s' matched pattern /%s/", a:str, a:pattern),
           \ hint)
   else
-    call self.report_success()
+    return self.report_success()
   endif
 endfunction
 call s:Assertions.function('assert_not_match_C')
@@ -465,16 +465,16 @@ function! s:Assertions_assert_throw(exception, command, ...) dict
     execute a:command
   catch
     if v:exception !~# a:exception
-      call self.report_failure(
+      return self.report_failure(
             \ printf("Command '%s' didn't throw /%s/, but threw:\n%s",
             \   a:command, a:exception, v:exception),
             \ hint)
     else
-      call self.report_success()
+      return self.report_success()
     endif
     return
   endtry
-  call self.report_failure(
+  return self.report_failure(
         \ empty(a:exception)
         \   ? printf("Command '%s' didn't throw anything.", a:command)
         \   : printf("Command '%s' didn't throw /%s/\nNothing thrown.",
@@ -495,12 +495,12 @@ function! s:Assertions_assert_not_throw(command, ...) dict
   try
     execute a:command
   catch
-    call self.report_failure(
+    return self.report_failure(
           \ printf("Command '%s' threw:\n%s", a:command, v:exception),
           \ hint)
     return
   endtry
-  call self.report_success()
+  return self.report_success()
 endfunction
 call s:Assertions.function('assert_not_throw')
 call s:Assertions.alias('assert_nothing_thrown', 'assert_not_throw')
@@ -521,14 +521,14 @@ call s:Assertions.function('count_assertion')
 
 function! s:Assertions_report_success() dict
   if has_key(self, 'runner')
-    call self.runner.report_success()
+    return self.runner.report_success()
   endif
 endfunction
 call s:Assertions.function('report_success')
 
 function! s:Assertions_report_failure(reason, hint) dict
   if has_key(self, 'runner')
-    call self.runner.report_failure(a:reason, a:hint)
+    return self.runner.report_failure(a:reason, a:hint)
   else
     let msg = substitute(a:reason, "\n", ' ', 'g')
     if !empty(a:hint)

--- a/autoload/unittest/oop.vim
+++ b/autoload/unittest/oop.vim
@@ -46,7 +46,7 @@ function! unittest#oop#__constant__(name)
 endfunction
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/oop/class.vim
+++ b/autoload/unittest/oop/class.vim
@@ -36,7 +36,7 @@ let s:TYPE_NUM  = type(0)
 let s:TYPE_FUNC = type(function('tr'))
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/oop/module.vim
+++ b/autoload/unittest/oop/module.vim
@@ -35,7 +35,7 @@ set cpo&vim
 let s:TYPE_NUM  = type(0)
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/autoload/unittest/testcase.vim
+++ b/autoload/unittest/testcase.vim
@@ -32,7 +32,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:get_SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '<SNR>\d\+_\zeget_SID')
 endfunction
 let s:SID = s:get_SID()
 delfunction s:get_SID

--- a/bin/vunit
+++ b/bin/vunit
@@ -29,7 +29,8 @@
 # }}}
 #=============================================================================
 
-set -o errexit
+# removed because we want to grep the resulting file for test errors and failures
+# set -o errexit
 set -o nounset
 
 NAME=vunit
@@ -116,7 +117,9 @@ tcfile=`basename "$1"`
 check_path "$tcfile"
 
 cwd=`pwd`
-trap 'cd "$cwd"; exit 0' EXIT
+test_has_failed=0
+
+trap 'cd "$cwd"; exit $test_has_failed' EXIT
 trap 'cd "$cwd"; exit 1' HUP INT QUIT TERM
 cd "$tcdir"
 
@@ -124,10 +127,15 @@ if [ $OUTPUT = FILE ]; then
   outfile=`mktemp -t vunit_results.XXXXXXXXXX`
   check_path "$outfile"
   trap - EXIT HUP INT QUIT TERM
-  trap 'rm -f "$outfile"; exit 0;' EXIT
+  trap 'rm -f "$outfile"; exit $test_has_failed;' EXIT
   trap 'rm -f "$outfile"; exit 1;' HUP INT QUIT TERM
 
   $VIM -c "UnitTest $tcfile >$outfile" -c "qall!"
+
+  ls
+
+  grep "0 failures, 0 errors" $outfile
+  test_has_failed=$?
 
   if [ $COLOR = NONE ]; then
     cat "$outfile"
@@ -176,6 +184,7 @@ if [ $OUTPUT = FILE ]; then
       { print }
     '
   fi
+  exit $test_has_failed
 else
   $VIM -c "UnitTest $tcfile" -c 'wincmd o' -c 'normal! z-'
 fi

--- a/bin/vunit
+++ b/bin/vunit
@@ -124,8 +124,8 @@ if [ $OUTPUT = FILE ]; then
   outfile=`mktemp -t vunit_results.XXXXXXXXXX`
   check_path "$outfile"
   trap - EXIT HUP INT QUIT TERM
-  trap 'rm -f "$outfile"; cd "$tcdir" exit 0' EXIT
-  trap 'rm -f "$outfile"; cd "$tcdir" exit 1' HUP INT QUIT TERM
+  trap 'rm -f "$outfile"; cd "$tcdir"; exit 0;' EXIT
+  trap 'rm -f "$outfile"; cd "$tcdir"; exit 1;' HUP INT QUIT TERM
 
   $VIM -c "UnitTest $tcfile >$outfile" -c "qall!"
 

--- a/bin/vunit
+++ b/bin/vunit
@@ -124,8 +124,8 @@ if [ $OUTPUT = FILE ]; then
   outfile=`mktemp -t vunit_results.XXXXXXXXXX`
   check_path "$outfile"
   trap - EXIT HUP INT QUIT TERM
-  trap 'rm -f "$outfile"; cd "$tcdir"; exit 0;' EXIT
-  trap 'rm -f "$outfile"; cd "$tcdir"; exit 1;' HUP INT QUIT TERM
+  trap 'rm -f "$outfile"; exit 0;' EXIT
+  trap 'rm -f "$outfile"; exit 1;' HUP INT QUIT TERM
 
   $VIM -c "UnitTest $tcfile >$outfile" -c "qall!"
 

--- a/doc/unittest.txt
+++ b/doc/unittest.txt
@@ -393,6 +393,9 @@ ASSERTIONS					*unittest-assertions*
 	given, it would be appended to the failure message to give additional
 	information if the assertion failed.
 
+	NOTE: All assertions return 0 in case of failure and 1 in case of
+	success.
+
 
 	assert( {expr} [, {hint}])		*unittest-assert()*
 
@@ -582,6 +585,29 @@ ASSERTIONS					*unittest-assertions*
 	assert_nothing_thrown( {ex-command} [, {hint}])
 
 		Expects {ex-command} to throw nothing.
+	
+PSEUDO-ASSERTIONS
+	Those pseudo assertions are usefull when you want to implement your
+	own comparison methods.
+						*unittest-fail()*
+	fail([{hint}])
+		Manual fail for the test.
+
+		Example: >
+		if a != b
+		call self.fail("a and b are different")
+		endif
+<
+	
+						*unittest-pass()*
+	pass()
+		Manual pass for the test.
+
+		Example: >
+		if a == b
+		call self.pass()
+		endif
+<
 
 CONTEXT ACCESSORS				*unittest-context-accessors*
 

--- a/test/test_assert.vim
+++ b/test/test_assert.vim
@@ -16,203 +16,212 @@ let s:tc = unittest#testcase#new("Assertions")
 
 function! s:tc.test_assert()
   call self.assert(1)
-  call self.assert(0)
+  call self.assert(0,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not()
   call self.assert_not(0)
-  call self.assert_not(1)
+  call self.assert_not(1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_equal()
   call self.assert_equal(1, 1)
-  call self.assert_equal(1, 2)
+  call self.assert_equal(1, 2,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_equal()
   call self.assert_not_equal(1, 2)
-  call self.assert_not_equal(1, 1)
+  call self.assert_not_equal(1, 1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_equal_c()
   call self.assert_equal_c("a", "A")
-  call self.assert_equal_c("a", "b")
+  call self.assert_equal_c("a", "b","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_equal_q()
   call self.assert_equal_q("a", "A")
-  call self.assert_equal_q("a", "b")
+  call self.assert_equal_q("a", "b","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_equal_c()
   call self.assert_not_equal_c("a", "b")
-  call self.assert_not_equal_c("a", "A")
+  call self.assert_not_equal_c("a", "A","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_not_equal_q()
   call self.assert_not_equal_q("a", "b")
-  call self.assert_not_equal_q("a", "A")
+  call self.assert_not_equal_q("a", "A","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_equal_C()
   call self.assert_equal_C("a", "a")
-  call self.assert_equal_C("a", "b")
+  call self.assert_equal_C("a", "b","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_equal_s()
   call self.assert_equal_s("a", "a")
-  call self.assert_equal_s("a", "b")
+  call self.assert_equal_s("a", "b","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_equal_C()
   call self.assert_not_equal_C("a", "b")
-  call self.assert_not_equal_C("a", "a")
+  call self.assert_not_equal_C("a", "a","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_not_equal_s()
   call self.assert_not_equal_s("a", "b")
-  call self.assert_not_equal_s("a", "a")
+  call self.assert_not_equal_s("a", "a","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_exists()
   call self.assert_exists('*tr')
-  call self.assert_exists('*foo#bar#baz')
+  call self.assert_exists('*foo#bar#baz',"PASSED: Failed is the correct behavior")
 
   call self.assert_exists(':bnext')
-  call self.assert_exists(':bn')
+  call self.assert_exists(':bn',"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_exists()
   call self.assert_not_exists('*foo#bar#baz')
-  call self.assert_not_exists('*tr')
+  call self.assert_not_exists('*tr',"PASSED: Failed is the correct behavior")
 
   call self.assert_not_exists(':bn')
-  call self.assert_not_exists(':bnext')
+  call self.assert_not_exists(':bnext',"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_has_key()
   call self.assert_has_key('a', { 'a': 10 })
-  call self.assert_has_key('b', { 'a': 10 })
+  call self.assert_has_key('b', { 'a': 10 },"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_has_key()
   call self.assert_not_has_key('b', { 'a': 10 })
-  call self.assert_not_has_key('a', { 'a': 10 })
+  call self.assert_not_has_key('a', { 'a': 10 },"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is()
   let a = []
   let b = []
   call self.assert_is(a, a)
-  call self.assert_is(a, b)
+  call self.assert_is(a, b,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_isnot()
   let a = []
   let b = []
   call self.assert_isnot(a, b)
-  call self.assert_isnot(a, a)
+  call self.assert_isnot(a, a,"PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_is_not()
   let a = []
   let b = []
   call self.assert_is_not(a, b)
-  call self.assert_is_not(a, a)
+  call self.assert_is_not(a, a,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is_Number()
   call self.assert_is_Number(1)
-  call self.assert_is_Number("a")
+  call self.assert_is_Number("a","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is_String()
   call self.assert_is_String("a")
-  call self.assert_is_String(1)
+  call self.assert_is_String(1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is_Funcref()
   call self.assert_is_Funcref(function("type"))
-  call self.assert_is_Funcref(1)
+  call self.assert_is_Funcref(1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is_List()
   call self.assert_is_List([1,2,3])
-  call self.assert_is_List(1)
+  call self.assert_is_List(1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is_Dictionary()
   call self.assert_is_Dictionary({ 1:'a', 2:'b' })
-  call self.assert_is_Dictionary(1)
+  call self.assert_is_Dictionary(1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_is_Float()
   call self.assert_is_Float(3.14)
-  call self.assert_is_Float(1)
+  call self.assert_is_Float(1,"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_match()
   call self.assert_match('e', "hello")
-  call self.assert_match('x', "hello")
+  call self.assert_match('x', "hello","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_match()
   call self.assert_not_match('x', "hello")
-  call self.assert_not_match('e', "hello")
+  call self.assert_not_match('e', "hello","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_match_c()
   call self.assert_match_c('e', "HELLO")
-  call self.assert_match_c('x', "HELLO")
+  call self.assert_match_c('x', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_match_q()
   call self.assert_match_q('e', "HELLO")
-  call self.assert_match_q('x', "HELLO")
+  call self.assert_match_q('x', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_match_c()
   call self.assert_not_match_c('x', "HELLO")
-  call self.assert_not_match_c('e', "HELLO")
+  call self.assert_not_match_c('e', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_not_match_q()
   call self.assert_not_match_q('x', "HELLO")
-  call self.assert_not_match_q('e', "HELLO")
+  call self.assert_not_match_q('e', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_match_C()
   call self.assert_match_C('E', "HELLO")
-  call self.assert_match_C('e', "HELLO")
+  call self.assert_match_C('e', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_match_s()
   call self.assert_match_s('E', "HELLO")
-  call self.assert_match_s('e', "HELLO")
+  call self.assert_match_s('e', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_match_C()
   call self.assert_not_match_C('e', "HELLO")
-  call self.assert_not_match_C('E', "HELLO")
+  call self.assert_not_match_C('E', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_not_match_s()
   call self.assert_not_match_s('e', "HELLO")
-  call self.assert_not_match_s('E', "HELLO")
+  call self.assert_not_match_s('E', "HELLO","PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_throw()
   call self.assert_throw('E492', 'FooBarBaz')
-  call self.assert_throw('E492', 'nohl')
+  call self.assert_throw('E492', 'nohl',"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_throw_something()
   call self.assert_throw_something('FooBarBaz')
-  call self.assert_throw_something('nohl')
+  call self.assert_throw_something('nohl',"PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_something_thrown()
   call self.assert_something_thrown('FooBarBaz')
-  call self.assert_something_thrown('nohl')
+  call self.assert_something_thrown('nohl',"PASSED: Failed is the correct behavior")
 endfunction
 
 function! s:tc.test_assert_not_throw()
   call self.assert_not_throw('nohl')
-  call self.assert_not_throw('FooBarBaz')
+  call self.assert_not_throw('FooBarBaz',"PASSED: Failed is the correct behavior")
 endfunction
 function! s:tc.test_assert_nothing_thrown()
   call self.assert_nothing_thrown('nohl')
-  call self.assert_nothing_thrown('FooBarBaz')
+  call self.assert_nothing_thrown('FooBarBaz',"PASSED: Failed is the correct behavior")
+endfunction
+
+function! s:tc.test_assert_return_values()
+    if !self.assert(1)
+        call self.assert(0,"Passing tests should return true")
+    endif
+    if self.assert(0,"PASSED: Failed is the correct behavior")
+        call self.assert(0,"Failing tests should return false")
+    endif
 endfunction
 
 function! s:tc.test_error()

--- a/test/test_assert.vim
+++ b/test/test_assert.vim
@@ -224,6 +224,16 @@ function! s:tc.test_assert_return_values()
     endif
 endfunction
 
+function! s:tc.test_pass_fail()
+    call self.fail("PASSED: (Manual fail) Failed is the correct behavior")
+    call self.pass()
+endfunction
+
+function! s:tc.test_pass_fail_returns()
+    call self.assert_equal(0,self.fail("PASSED: (expected Manual fail) Failed is the correct behavior"))
+    call self.assert_equal(0,self.pass(), "PASSED: (actual expected value should be 1)")
+endfunction
+
 function! s:tc.test_error()
   call foo#bar#baz()
 endfunction


### PR DESCRIPTION
`UnitTest` makes use of funcrefs defined as local script functions.
To allow the creation of a funcref, one should get the unique ID of the script that contains the function.
For example, the object `s:Assertions` that is defined in some script in the plugin's `autoload` path can be referenced as e.g. `<SNR>96_Assertions`
The functions `get_SID()` in the plugin's scripts are responsible for finding the sequence `<SNR>XXX_` from `<sfile>` to reference local functions in this script.

Sadly, the expansion of the `<sfile>`  have multiple occurences of the original match pattern and returned the SID of the base script, thus leading to invalid funcrefs.

Here's an example for the `get_SID()` function in `autoload/unittest/oop/module.vim`
The `<sfile>` expands to  `function unittest#run[8]..<SNR>90_TestRunner_load_testcases[5]..script test_yank_vhd.vim[74]..vim-unittest/autoload/unittest/testcase.
vim[70]..vim-unittest/autoload/unittest/assertions.vim[61]..vim-unittest/autoload/unittest/oop/module.vim[41]..function <SNR>96_get_SID`

The actual `<SID>` for the script `autoload/unittest/oop/module.vim` should be `<SNR>96_` but the original match pattern was capturing the first occurence of it (`<SNR>90_`), thus matching script `autoload/unittest.vim` instead of `autoload/unittest/oop/module.vim`

Fixes #8 